### PR TITLE
fix: add missing videoTimestamp

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -174,16 +174,16 @@ export default class SauceReporter extends SummaryFormatter {
     if (!this.suiteEndAt) {
       return;
     }
-    let currentTime = new Date(this.suiteEndAt);
+    let endTime = new Date(this.suiteEndAt);
 
     // Use reduceRight to iterate through the tests from last to first.
     suite.tests.reduceRight((_, test) => {
-      test.startTime = new Date(currentTime.getTime() - test.duration);
+      test.startTime = new Date(endTime.getTime() - test.duration);
       if (this.videoStartTime) {
         test.videoTimestamp =
           (test.startTime.getTime() - this.videoStartTime) / 1000;
       }
-      currentTime = test.startTime;
+      endTime = test.startTime;
 
       // We don't need to return anything since we're mutating the original array.
       return _;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -176,7 +176,7 @@ export default class SauceReporter extends SummaryFormatter {
     }
     let currentTime = new Date(this.suiteEndAt);
 
-    // Use reduceRight to iterate through the testSteps from last to first.
+    // Use reduceRight to iterate through the tests from last to first.
     suite.tests.reduceRight((_, test) => {
       test.startTime = new Date(currentTime.getTime() - test.duration);
       if (this.videoStartTime) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -171,19 +171,17 @@ export default class SauceReporter extends SummaryFormatter {
   // Calculate each test's startTime and videoTimestamp.
   calculateTestTiming(suite: Suite, endTime: Date) {
     let currEndTime = endTime;
+    for (let i = suite.tests.length - 1; i >= 0; i--) {
+      const test = suite.tests[i];
+      const startTime = new Date(currEndTime.getTime() - test.duration);
 
-    // Use reduceRight to iterate through the tests from last to first.
-    suite.tests.reduceRight((_, test) => {
-      test.startTime = new Date(currEndTime.getTime() - test.duration);
+      suite.tests[i].startTime = startTime;
       if (this.videoStartTime) {
-        test.videoTimestamp =
-          (test.startTime.getTime() - this.videoStartTime) / 1000;
+        suite.tests[i].videoTimestamp =
+          (startTime.getTime() - this.videoStartTime) / 1000;
       }
       currEndTime = test.startTime;
-
-      // We don't need to return anything since we're mutating the original array.
-      return _;
-    }, null);
+    }
   }
 
   async logTestRun(testRunFinished: { success: boolean }) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -134,6 +134,7 @@ export default class SauceReporter extends SummaryFormatter {
       sourceLocation: parsed.testCase?.sourceLocation,
     };
 
+    let startTime: Date;
     parsed.testSteps.forEach((testStep: any) => {
       const test = new Test(`${testStep.keyword}${testStep.text || ''}`);
       const testStatus = testStep.result?.status?.toLowerCase();
@@ -145,8 +146,13 @@ export default class SauceReporter extends SummaryFormatter {
             : SauceStatus.Failed;
       test.output = testStep.result?.message;
       test.duration = this.durationToMilliseconds(testStep.result?.duration);
+      startTime = startTime
+        ? new Date(startTime.getTime() + test.duration)
+        : new Date();
+      test.startTime = startTime;
       if (this.videoStartTime) {
-        test.videoTimestamp = (Date.now() - this.videoStartTime) / 1000;
+        test.videoTimestamp =
+          (test.startTime.getTime() - this.videoStartTime) / 1000;
       }
       test.attachments = [];
       testStep.attachments.forEach((attachment: any) => {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -33,6 +33,7 @@ export default class SauceReporter extends SummaryFormatter {
   startedAt?: string;
   endedAt?: string;
   videoStartTime?: number;
+  videoTimestamp?: number;
   consoleLog: string[];
   passed: boolean;
   baseLog: (buffer: string | Uint8Array) => void;
@@ -144,6 +145,9 @@ export default class SauceReporter extends SummaryFormatter {
             : SauceStatus.Failed;
       test.output = testStep.result?.message;
       test.duration = this.durationToMilliseconds(testStep.result?.duration);
+      if (this.videoStartTime) {
+        test.videoTimestamp = (Date.now() - this.videoStartTime) / 1000;
+      }
       test.attachments = [];
       testStep.attachments.forEach((attachment: any) => {
         const r = new stream.Readable();

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -164,13 +164,14 @@ export default class SauceReporter extends SummaryFormatter {
       });
       curr.addTest(test);
     });
-    this.calculateStartTime(curr);
+    this.calculateTestTiming(curr);
     suite.addSuite(curr);
     this.testRun.addSuite(suite);
   }
 
-  // Calculate each test's start time using the suite's end time and test duration.
-  calculateStartTime(suite: Suite) {
+  // Calculate each test's startTime and videoTimestamp
+  // using the suite's end time and test duration.
+  calculateTestTiming(suite: Suite) {
     if (!this.suiteEndAt) {
       return;
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -164,12 +164,13 @@ export default class SauceReporter extends SummaryFormatter {
       });
       curr.addTest(test);
     });
-    this.calculateStartTimes(curr);
+    this.calculateStartTime(curr);
     suite.addSuite(curr);
     this.testRun.addSuite(suite);
   }
 
-  calculateStartTimes(suite: Suite) {
+  // Calculate each test's start time using the suite's end time and test duration.
+  calculateStartTime(suite: Suite) {
     if (!this.suiteEndAt) {
       return;
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -169,8 +169,7 @@ export default class SauceReporter extends SummaryFormatter {
     this.testRun.addSuite(suite);
   }
 
-  // Calculate each test's startTime and videoTimestamp
-  // using the suite's end time and test duration.
+  // Calculate each test's startTime and videoTimestamp.
   calculateTestTiming(suite: Suite) {
     if (!this.suiteEndAt) {
       return;


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

- Correct `startTime` of each test.
- Add missing `videoTimestamp` for web UI display.

What we can get from cucumber is just test's duration. `startTime` can be calculated by suite finished time and test duration.

Job: https://app.saucelabs.com/tests/22392ed9b0cd42b9b059e3cf00bee9ae#6