### PR TITLE
refactor: use name instead of suiteName

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example `cucumber.json`:
     "requireModule": ["ts-node/register"],
     "format": "@saucelabs/cucumber-reporter",
     "formatOptions": {
-      "suiteName": "my cucumber test",
+      "name": "my cucumber test",
       "build": "mybuild",
       "tags": ["demo", "e2e", "cucumber"],
       "region": "eu-central-1"
@@ -64,4 +64,4 @@ Configuration Parameters:
 | `region`      | Sets the region. Default: `us-west-1`.                                            | `String`   |
 | `upload`      | Whether to upload report and assets to Sauce. Default: `true`.                    | `boolean`  |
 | `outputFile`  | The local path to write the sauce test report. Default: `sauce-test-report.json`. | `String`   |
-| `suiteName`   | Sets the suite name. Default: `Unnamed job ${job_id}`.                            | `String`   |
+| `name`        | Sets the job name. Default: `Unnamed job ${job_id}`.                              | `String`   |

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -24,6 +24,10 @@ const isAccountSet = () => {
 
 export default class SauceReporter extends SummaryFormatter {
   testRun: TestRun;
+  name: string;
+  /**
+   * @deprecated Use `name` instead.
+   */
   suiteName: string;
   browserName: string;
   build: string;
@@ -54,6 +58,10 @@ export default class SauceReporter extends SummaryFormatter {
     this.baseLog = this.log;
     this.log = this.logWrapper;
     this.suiteName = reporterConfig?.suiteName || '';
+    this.name = reporterConfig?.name || '';
+    if (this.suiteName && !this.name) {
+      this.name = this.suiteName;
+    }
     this.browserName = reporterConfig?.browserName || 'chrome';
     this.build = reporterConfig?.build || '';
     this.tags = reporterConfig?.tags || [];
@@ -211,7 +219,7 @@ export default class SauceReporter extends SummaryFormatter {
 
   async reportToSauce() {
     const job = await this.testComposer?.createReport({
-      name: this.suiteName,
+      name: this.name,
       startTime: this.startedAt || '',
       endTime: this.endedAt || '',
       framework: 'cucumber',

--- a/tests/integration/cucumber.json
+++ b/tests/integration/cucumber.json
@@ -1,18 +1,12 @@
 {
   "default": {
-    "requireModule": [
-      "ts-node/register"
-    ],
+    "requireModule": ["ts-node/register"],
     "formatOptions": {
-      "suiteName": "my cucumber test",
+      "name": "my cucumber test",
       "build": "mybuild",
       "tags": ["demo", "e2e", "cucumber"]
     },
-    "paths": [
-      "**/features/**/*.feature"
-    ],
-    "require": [
-      "tests/integration/features/step_definitions/*.ts"
-    ]
+    "paths": ["**/features/**/*.feature"],
+    "require": ["tests/integration/features/step_definitions/*.ts"]
   }
 }


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

I can't recall why I set a `suiteName` as the job name. But since it's only for reporting a job, use `name` instead.